### PR TITLE
Ignore \r to avoid errors

### DIFF
--- a/src/format.pl
+++ b/src/format.pl
@@ -95,6 +95,7 @@ while ( <STDIN> ) {
 
     if (/<\/ENTRY>/) {
 	if ($start_flag) {
+            $article =~ s/\r//g;
 	    &check_article($aid, $title, $article);
 	    # 記事に区切るだけ
 	    # print "$aid\n$title\n$article\n\n";
@@ -105,6 +106,7 @@ while ( <STDIN> ) {
     } elsif (/<C0>/) {
 	/^<C0>(.+)<\/C0>\n/;
 	$aid = $1;
+	$aid =~ s/\r//g;
 	if ($aid =~ /^$DATE/) {
 	    $start_flag = 1;
 	} else {


### PR DESCRIPTION
`\r` causes errors such as
```txt
Can't find 950117002-001 in ./dat/num/950117.org at ./src/num2KNP.pl line 44, <ORG> line 4686.
```

Tested in `Perl v5.32.0 on Mac OS` and `Perl v5.30.3 on Debian`.